### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   fuzz-nightly:
     name: Nightly Fuzzing
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/reglet-dev/reglet/security/code-scanning/1](https://github.com/reglet-dev/reglet/security/code-scanning/1)

In general, this is fixed by adding a `permissions` block to the workflow or to the specific job, granting only the minimal scopes needed. For this job, it needs to be able to create GitHub issues (`issues: write`), and the rest of the steps (checkout, cache, upload-artifact) work with `contents: read` or even with no additional write permissions.

The best minimal fix without changing functionality is to add a job-level `permissions` block under `fuzz-nightly` that grants `contents: read` and `issues: write`. This allows the `actions/github-script` step to call `github.rest.issues.create` while ensuring the `GITHUB_TOKEN` cannot, for example, push code or modify other resources unnecessarily. Concretely, in `.github/workflows/fuzz.yml`, under `jobs: fuzz-nightly:`, insert:

```yaml
    permissions:
      contents: read
      issues: write
```

just after the `name: Nightly Fuzzing` (or before `runs-on:`), keeping indentation consistent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
