### PR TITLE
Potential fix for code scanning alert no. 3: Size computation for allocation may overflow

### DIFF
--- a/internal/infrastructure/sensitivedata/match.go
+++ b/internal/infrastructure/sensitivedata/match.go
@@ -3,7 +3,6 @@
 package sensitivedata
 
 import (
-	"math"
 	"sort"
 )
 
@@ -70,26 +69,9 @@ func ApplyReplacements(input string, matches []Match, replacement func(secret st
 		m := matches[i]
 		repl := replacement(m.Secret)
 
-		// Check for potential integer overflow before allocation
-		// calculatedCap = len(result) - len(m.Secret) + len(repl)
-		currentLen := len(result)
-		removedLen := len(m.Secret)
-		addedLen := len(repl)
-
-		// currentLen - removedLen is safe because the match is within the string
-		baseLen := currentLen - removedLen
-
-		// Check if adding addedLen would overflow int
-		// efficient check: if baseLen > math.MaxInt - addedLen
-		if baseLen > math.MaxInt-addedLen {
-			// Fallback to safe append which might panic nicely or handle it,
-			// checking specifically for this prevents undefined behavior or wrap-around allocation
-			// Since we can't return an error here, and we can't allocate, we panic with a clear message.
-			panic("sensitivedata: string length overflow")
-		}
-
-		// Replace [Start:End] with replacement
-		newResult := make([]byte, 0, baseLen+addedLen)
+		// Replace [Start:End] with replacement.
+		// We let append and the runtime manage capacity to avoid manual size arithmetic.
+		newResult := make([]byte, 0)
 		newResult = append(newResult, result[:m.Start]...)
 		newResult = append(newResult, repl...)
 		newResult = append(newResult, result[m.End:]...)


### PR DESCRIPTION
Potential fix for [https://github.com/reglet-dev/reglet/security/code-scanning/3](https://github.com/reglet-dev/reglet/security/code-scanning/3)

In general, to fix size-computation-overflow issues in allocations, avoid manual arithmetic on potentially large lengths where possible, or guard it explicitly. When working with `int` lengths derived from untrusted or very large data, either (a) validate the total size up front, (b) use checked arithmetic to ensure sums don’t exceed `math.MaxInt`, or (c) rely on `append` with a zero initial length and no explicit capacity, so that the Go runtime handles capacity growth safely.

For this case, the simplest fix without changing observable functionality is:

- Remove the manual capacity computation `baseLen + addedLen` used in `make`, which is what CodeQL considers risky.
- Instead, build `newResult` incrementally using `append` starting from `nil` (or `make([]byte, 0)` with no explicit capacity). This eliminates the explicit overflow-prone size computation; the runtime will determine appropriate capacities internally and will panic in a controlled way if allocation is impossible.
- Retain the existing logical behavior: the final contents and returned string remain the same; only the internal allocation strategy changes slightly (potentially a tiny performance impact but negligible given correctness and safety).
- As an additional safety improvement, validate that each `Match` is well-formed with respect to `result` before using its indices (ensuring `0 <= m.Start <= m.End <= len(result)` and that `len(m.Secret) == m.End-m.Start`). However, this is optional from the static-analysis point of view; strictly speaking, just removing the explicit `baseLen+addedLen` in the `make` call addresses the reported overflow concern.

Concretely, in `internal/infrastructure/sensitivedata/match.go`:

- In `ApplyReplacements`, remove the capacity arithmetic and the `math.MaxInt` check.
- Replace:

```go
// Check for potential integer overflow before allocation
// calculatedCap = len(result) - len(m.Secret) + len(repl)
currentLen := len(result)
removedLen := len(m.Secret)
addedLen := len(repl)

// currentLen - removedLen is safe because the match is within the string
baseLen := currentLen - removedLen

// Check if adding addedLen would overflow int
// efficient check: if baseLen > math.MaxInt - addedLen
if baseLen > math.MaxInt-addedLen {
    ...
}

// Replace [Start:End] with replacement
newResult := make([]byte, 0, baseLen+addedLen)
```

with a simpler, safe construction:

```go
// Replace [Start:End] with replacement
newResult := make([]byte, 0)
```

and keep the three `append` calls unchanged. No new imports or helper methods are needed; in fact we can also drop the now-unused `math` import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
